### PR TITLE
feat: add Scope

### DIFF
--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -5,6 +5,9 @@ module type Param = Action.Param
 module type S =
 sig
   include Param
+
+  exception RecursiveLocking
+
   module Act : Action.S with type data = data and type hook = hook
 
   val resolve : Trie.path -> data option
@@ -62,9 +65,12 @@ struct
 
   open Internal
 
+  exception RecursiveLocking = M.RecursiveLocking
+
   module Act = Internal.A
 
-  let resolve p = resolve p
+  let resolve p =
+    M.exclusively @@ fun () -> resolve p
 
   let run_on_visible ?prefix pat =
     M.exclusively @@ fun () -> S.modify @@ fun s ->

--- a/src/Scope.mli
+++ b/src/Scope.mli
@@ -1,0 +1,22 @@
+module type Param = Action.Param
+
+module type S =
+sig
+  include Param
+
+  exception RecursiveLocking
+
+  module Act : Action.S with type data = data and type hook = hook
+
+  val resolve : Trie.path -> data option
+  val run_on_visible : ?prefix:Trie.bwd_path -> hook Pattern.t -> unit
+  val run_on_export : ?prefix:Trie.bwd_path -> hook Pattern.t -> unit
+  val export_visible : ?prefix:Trie.bwd_path -> hook Pattern.t -> unit
+  val include_singleton : ?prefix:Trie.bwd_path -> Trie.path * data -> unit
+  val include_subtree : ?prefix:Trie.bwd_path -> Trie.path * data Trie.t -> unit
+  val import_subtree : ?prefix:Trie.bwd_path -> Trie.path * data Trie.t -> unit
+  val run : (unit -> 'a) -> 'a
+  val section : ?prefix:Trie.bwd_path -> Trie.path -> (unit -> 'a) -> 'a
+end
+
+module Make (P : Param) : S with type data = P.data and type hook = P.hook

--- a/src/Yuujinchou.ml
+++ b/src/Yuujinchou.ml
@@ -1,3 +1,4 @@
 module Trie = Trie
 module Pattern = Pattern
 module Action = Action
+module Scope = Scope

--- a/src/Yuujinchou.mli
+++ b/src/Yuujinchou.mli
@@ -102,7 +102,7 @@ import math # Python: the sqrt function is available as `math.sqrt`.
 
    {2 Library Organization}
 
-   The library code is split into three parts:
+   The library code is split into four parts: (The {!module:Scope} is new.)
 *)
 
 (** The {!module:Trie} module implements mappings from paths to values that support efficient subtree operations. *)
@@ -291,8 +291,8 @@ sig
     (** Execute the code that performs scoping effects. *)
 
     val section : ?prefix:Trie.bwd_path -> Trie.path -> (unit -> 'a) -> 'a
-    (** [section ?prefix p f] starts a new section and runs the code [f] with the prefix [p].
-        The child scope inherits the visible namespace from the parent, and the export namespace
+    (** [section ?prefix p f] starts a new scope and runs the thunk [f] within the scope.
+        The child scope inherits the visible namespace from the parent, and its export namespace
         will be prefixed with [p] and merged into both the visible and export namespaces
         of the parent scope.
 


### PR DESCRIPTION
This PR adds an effect-based scoping mechanism. Closes #60. The highlight is that we couldn't easily write the following function (that can be integrated into cooltt) because we wouldn't know what monad `m` would be: (And, it's painful to use functors to abstract over `m`.)
```ocaml
(* start a new section in the current scope *)
val section : ?prefix:Trie.bwd_path -> Trie.path -> (unit -> m 'a) -> m 'a
```
Now, using algebraic effects, this function is just a few lines of simple code:
```ocaml
let section ?prefix p f =
  M.exclusively @@ fun () ->
  let ans, export =
    run_scope ~init_visible:(S.get()).visible @@ fun () ->
    let ans = f () in ans, (S.get()).export
  in
  include_subtree ?prefix (p, export);
  ans
```
This function really shows how composable algebraic effects are!