### PR TITLE
🛐 Worship the OCaml module system

### DIFF
--- a/docs/design.mld
+++ b/docs/design.mld
@@ -58,7 +58,7 @@ To recover efficient group operations on implicit namespaces as one might expect
 
 {2 No No-Ops}
 
-Hiding, renaming, selecting, and excluding modifiers must match at least one existing binding. For example, if there is no binding with the prefix [x], then selecting the namespace rooted at [x] should fail or at least produce a warning. The reason is that the lack of matching bindings strongly indicates a typo. In this library, such an error will trigger the effect {{!field:Yuujinchou.Modifier.not_found}not_found}.
+Hiding, renaming, selecting, and excluding modifiers must match at least one existing binding. For example, if there is no binding with the prefix [x], then selecting the namespace rooted at [x] should fail or at least produce a warning. The reason is that the lack of matching bindings strongly indicates a typo. In this library, such an error will trigger the effect {{!val:Yuujinchou.Modifier.S.Handler.not_found}not_found}.
 
 As a consequence of this principle, a modifier cannot be understood as a function from an old name to a set of new names, but a function from an old namespace (implemented as a {{!module:Yuujinchou.Trie}trie} in this library) to a new namespace. Otherwise, it is difficult or impossible to detect whether there are unexpected no-ops.
 

--- a/src/Language.mli
+++ b/src/Language.mli
@@ -8,22 +8,4 @@ type 'hook t =
   | M_union of 'hook t list
   | M_hook of 'hook
 
-val equal : ('hook -> 'hook -> bool) -> 'hook t -> 'hook t -> bool
-
-val any : 'hook t
-
-val only : Trie.path -> 'hook t
-
-val none : 'hook t
-val except : Trie.path -> 'hook t
-val in_ : Trie.path -> 'hook t -> 'hook t
-
-val renaming : Trie.path -> Trie.path -> 'hook t
-
-val seq : 'hook t list -> 'hook t
-
-val union : 'hook t list -> 'hook t
-
-val hook : 'hook -> 'hook t
-
-val dump : (Format.formatter -> 'hook -> unit) -> Format.formatter -> 'hook t -> unit
+include LanguageSigs.S with type 'hook t := 'hook t

--- a/src/LanguageSigs.ml
+++ b/src/LanguageSigs.ml
@@ -1,0 +1,68 @@
+module type S =
+sig
+  (** {1 Types} *)
+
+  (** The abstract type of modifiers, parametrized by the type of hook labels. See {!val:hook} for hook labels.
+
+      Construct terms using builders in {!module:Language} and execute them using {!val:Modifier.S.modify}. *)
+  type 'hook t
+
+  (** Checking equality. *)
+  val equal : ('hook -> 'hook -> bool) -> 'hook t -> 'hook t -> bool
+
+  (** {1 Modifier Builders} *)
+
+  (** {2 Basics} *)
+
+  (** [any] keeps the content of the current tree. It is an error if the tree is empty (no name to match).
+      To avoid the emptiness checking, use the identity modifier {!val:seq}[ []].
+      This is equivalent to {!val:only}[ []]. *)
+  val any : 'hook t
+
+  (** [only path] keeps the subtree rooted at [path]. It is an error if the subtree was empty. *)
+  val only : Trie.path -> 'hook t
+
+  (** [in_ path m] runs the modifier [m] on the subtree rooted at [path]. Bindings outside the subtree are kept intact. For example, [in_ ["x"] ]{!val:any} will keep [y] (if existing), while {!val:only}[ ["x"]] will drop [y]. *)
+  val in_ : Trie.path -> 'hook t -> 'hook t
+
+  (** {2 Negation} *)
+
+  (** [none] drops everything. It is an error if the tree was already empty (nothing to drop).
+      To avid the emptiness checking, use the empty modifier {!val:union}[ []]. *)
+  val none : 'hook t
+
+  (** [except p] drops the subtree rooted at [p]. It is an error if there was nothing in the subtree. This is equivalent to {!val:in_}[ p ]{!val:none}. *)
+  val except : Trie.path -> 'hook t
+
+  (** {2 Renaming} *)
+
+  (** [renaming path path'] relocates the subtree rooted at [path] to [path']. The existing bindings at [path'] (if any) will be dropped.
+      It is an error if the subtree was empty (nothing to move). *)
+  val renaming : Trie.path -> Trie.path -> 'hook t
+
+  (** {2 Sequencing} *)
+
+  (** [seq [m0; m1; m2; ...; mn]] runs the modifiers [m0], [m1], [m2], ..., [mn] in order.
+      In particular, [seq []] is the identity modifier. *)
+  val seq : 'hook t list -> 'hook t
+
+  (** {2 Union} *)
+
+  (** [union [m0; m1; m2; ...; mn]] calculates the union of the results of individual modifiers [m0], [m1], [m2], ..., [mn].
+      In particular, [union []] is the empty modifier.
+      The {!field:Modifier.shadow} effect will be performed to resolve name conflicts,
+      with an intention for results of a modifier to shadow those of previous ones. *)
+  val union : 'hook t list -> 'hook t
+
+  (** {2 Custom Hooks} *)
+
+  (** [hook h] applies the hook labelled [h] to the entire trie
+      by performing the {!field:Modifier.hook} effect. *)
+  val hook : 'hook -> 'hook t
+
+  (** {2 Ugly Printing} *)
+
+  (** [dump dump_hook m] dumps the internal representation of [m] for debugging,
+      where [dump_hook] is the ugly printer for hook labels (see {!val:hook}). *)
+  val dump : (Format.formatter -> 'hook -> unit) -> Format.formatter -> 'hook t -> unit [@@ocaml.toplevel_printer]
+end

--- a/src/LanguageSigs.ml
+++ b/src/LanguageSigs.ml
@@ -50,14 +50,14 @@ sig
 
   (** [union [m0; m1; m2; ...; mn]] calculates the union of the results of individual modifiers [m0], [m1], [m2], ..., [mn].
       In particular, [union []] is the empty modifier.
-      The {!field:Modifier.shadow} effect will be performed to resolve name conflicts,
+      The {!val:Modifier.S.Handler.shadow} effect will be performed to resolve name conflicts,
       with an intention for results of a modifier to shadow those of previous ones. *)
   val union : 'hook t list -> 'hook t
 
   (** {2 Custom Hooks} *)
 
   (** [hook h] applies the hook labelled [h] to the entire trie
-      by performing the {!field:Modifier.hook} effect. *)
+      by performing the {!val:Modifier.S.Handler.hook} effect. *)
   val hook : 'hook -> 'hook t
 
   (** {2 Ugly Printing} *)

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -6,12 +6,12 @@ module type Param = Param
 module type Handler = Handler
 module type S = ModifierSigs.S with module Language := Language
 
-module Make (P : Param) : S with module P := P =
+module Make (Param : Param) : S with module Param := Param =
 struct
-  module type Handler = Handler with module P := P
+  module type Handler = Handler with module Param := Param
 
   module Language = Language
-  open P
+  open Param
 
   module Perform =
   struct

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -8,6 +8,8 @@ module type S = ModifierSigs.S with module Language := Language
 
 module Make (P : Param) : S with module P := P =
 struct
+module type Handler = Handler with module P := P
+
   module Language = Language
   open P
 
@@ -48,7 +50,7 @@ struct
       | L.M_hook id -> hook context prefix id t
     in go prefix
 
-  module Run (H : Handler with module P := P) =
+  module Run (H : Handler) =
   struct
     open Effect.Deep
 

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -1,41 +1,14 @@
 open Bwd
 open BwdNotation
+open ModifierSigs
 
-module type Param =
-sig
-  type data
-  type tag
-  type hook
-  type context
-end
-
-module type Handler =
-sig
-  module P : Param
-  val not_found : P.context option -> Trie.bwd_path -> unit
-  val shadow : P.context option -> Trie.bwd_path -> P.data * P.tag -> P.data * P.tag -> P.data * P.tag
-  val hook : P.context option -> Trie.bwd_path -> P.hook -> (P.data, P.tag) Trie.t -> (P.data, P.tag) Trie.t
-end
-
-
-module type S =
-sig
-  module P : Param
-  open P
-
-  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-
-  module Handle (H : Handler with module P := P) :
-  sig
-    val run : (unit -> 'a) -> 'a
-    val try_with : (unit -> 'a) -> 'a
-  end
-
-  module Perform : Handler with module P := P
-end
+module type Param = Param
+module type Handler = Handler
+module type S = ModifierSigs.S with module Language := Language
 
 module Make (P : Param) : S with module P = P =
 struct
+  module Language = Language
   module P = P
   include P
 
@@ -99,5 +72,4 @@ struct
     module P = P
     include Internal
   end
-
 end

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -58,7 +58,7 @@ struct
         Algaeff.Fun.Deep.finally k @@ fun () -> H.not_found context prefix
       | Shadow {context; path; former; latter} -> Option.some @@ fun (k : (a, _) continuation) ->
         Algaeff.Fun.Deep.finally k @@ fun () -> H.shadow context path former latter
-      | Hook {context; prefix; hook; input}-> Option.some @@ fun (k : (a, _) continuation) ->
+      | Hook {context; prefix; hook; input} -> Option.some @@ fun (k : (a, _) continuation) ->
         Algaeff.Fun.Deep.finally k @@ fun () -> H.hook context prefix hook input
       | _ -> None
 

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -48,7 +48,7 @@ struct
       | L.M_hook id -> hook context prefix id t
     in go prefix
 
-  module Handle (H : Handler with module P := P) =
+  module Run (H : Handler with module P := P) =
   struct
     open Effect.Deep
 

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -50,7 +50,6 @@ struct
 
   module Handle (H : Handler with module P := P) =
   struct
-
     let run f =
       let open Effect.Deep in
       try_with f ()

--- a/src/Modifier.ml
+++ b/src/Modifier.ml
@@ -8,7 +8,7 @@ module type S = ModifierSigs.S with module Language := Language
 
 module Make (P : Param) : S with module P := P =
 struct
-module type Handler = Handler with module P := P
+  module type Handler = Handler with module P := P
 
   module Language = Language
   open P

--- a/src/Modifier.mli
+++ b/src/Modifier.mli
@@ -1,35 +1,8 @@
 (* See Yuujinchou.mli for documentation. *)
+open ModifierSigs
 
-module type Param =
-sig
-  type data
-  type tag
-  type hook
-  type context
-end
+module type Param = Param
+module type Handler = Handler
+module type S = ModifierSigs.S with module Language := Language
 
-module type Handler =
-sig
-  module P : Param
-  val not_found : P.context option -> Trie.bwd_path -> unit
-  val shadow : P.context option -> Trie.bwd_path -> P.data * P.tag -> P.data * P.tag -> P.data * P.tag
-  val hook : P.context option -> Trie.bwd_path -> P.hook -> (P.data, P.tag) Trie.t -> (P.data, P.tag) Trie.t
-end
-
-module type S =
-sig
-  module P : Param
-  open P
-
-  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-
-  module Handle (H : Handler with module P := P) :
-  sig
-    val run : (unit -> 'a) -> 'a
-    val try_with : (unit -> 'a) -> 'a
-  end
-
-  module Perform : Handler with module P := P
-end
-
-module Make (P : Param) : S with module P = P
+module Make (P : Param) : S with module P := P

--- a/src/Modifier.mli
+++ b/src/Modifier.mli
@@ -4,4 +4,4 @@ open ModifierSigs
 module type Param = Param
 module type S = ModifierSigs.S with module Language := Language
 
-module Make (P : Param) : S with module P := P
+module Make (Param : Param) : S with module Param := Param

--- a/src/Modifier.mli
+++ b/src/Modifier.mli
@@ -2,7 +2,6 @@
 open ModifierSigs
 
 module type Param = Param
-module type Handler = Handler
 module type S = ModifierSigs.S with module Language := Language
 
 module Make (P : Param) : S with module P := P

--- a/src/ModifierSigs.ml
+++ b/src/ModifierSigs.ml
@@ -1,0 +1,71 @@
+
+(** The parameters of an engine. *)
+module type Param =
+sig
+  (** The type of data held by the bindings. The difference between data and tags is that the data will survive the efficient retagging. See {!val:Trie.retag}. *)
+  type data
+
+  (** The type of tags attached to the bindings. The difference between data and tags is that tags can be efficiently reset. See {!val:Trie.retag}. *)
+  type tag
+
+  (** The type of modifier hook labels. This is for extending the modifier language. *)
+  type hook
+
+  (** The type of contexts passed to each call of {!val:Modifier.S.modify} for the effect handler to distinguish different function calls. *)
+  type context
+end
+
+module type Handler =
+sig
+  module P : Param
+
+  val not_found : P.context option -> Trie.bwd_path -> unit
+  (** [not_found ctx prefix] is called when the engine expects at least one binding within the subtree at [prefix] but could not find any, where [ctx] is the context passed to {!val:S.modify}. Modifiers such as {!val:Language.any}, {!val:Language.only}, {!val:Language.none}, and a few other modifiers expect at least one matching binding. For example, the modifier {!val:Language.except}[ ["x"; "y"]] expects that there was already something under the subtree at [x.y]. If there were actually no names with the prefix [x.y], then the modifier will trigger this effect with [prefix] being [Emp #< "x" #< "y"]. *)
+
+  val shadow : P.context option -> Trie.bwd_path -> P.data * P.tag -> P.data * P.tag -> P.data * P.tag
+  (** [shadow ctx path x y] is called when item [y] is being assigned to [path] but [x] is already bound at [path], where [ctx] is the context passed to {!val:S.modify}. Modifiers such as {!val:Language.renaming} and {!val:Language.union} could lead to bindings having the same name, and when that happens, this function is called to resolve the conflicting bindings. To implement silent shadowing, one can simply return item [y]. One can also employ a more sophisticated strategy to implement type-directed disambiguation. *)
+
+
+  val hook : P.context option -> Trie.bwd_path -> P.hook -> (P.data, P.tag) Trie.t -> (P.data, P.tag) Trie.t
+  (** [hook prefix id input] is called when processing the modifiers created by {!val:Language.hook}, where [ctx] is the context passed to {!val:S.modify}. When the engine encounters the modifier {!val:Language.hook}[ id] while handling the subtree [input] at [prefix], it will call [hook prefix id input] and replace the existing subtree [input] with the return value. *)
+
+end
+
+module type S =
+sig
+  module Language : LanguageSigs.S
+
+  module P : Param
+  open P
+  (** @closed *)
+
+  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
+  (** [modify modifier trie] runs the [modifier] on the [trie] and return the transformed trie.
+
+      @param context The context sent to the effect handlers. If unspecified, effects come with {!constructor:None} as their context.
+      @param prefix The prefix prepended to any path or prefix sent to the effect handlers. The default is the empty path ([Emp]). *)
+
+  module Handle (H : Handler with module P := P) :
+  sig
+    val run : (unit -> 'a) -> 'a
+    (** [run f h] initializes the engine and runs the thunk [f], using [h] to handle modifier effects. See {!type:handler}. *)
+
+    val try_with : (unit -> 'a) -> 'a
+    (** [try_with f h] runs the thunk [f], using [h] to handle the intercepted modifier effects. See {!type:handler}.
+
+        Currently, [try_with] is an alias of {!val:run}, but [try_with] is intended to use within {!val:run} to intercept effects,
+        while {!val:run} is intended to be at the outermost layer to handle effects. That is, the following is the expected program structure:
+        {[
+          run @@ fun () ->
+          (* code *)
+          try_with f
+          (* more code *)
+        ]}
+    *)
+  end
+
+  module Perform : Handler with module P := P
+  (** A handler that reperforms the effects. It can also be used to manually trigger the effects;
+      for example, [Perform.not_found (Emp #< "a" #< "b")] will perform the [not_found] effect
+      to be handled by the outer handler. *)
+end

--- a/src/ModifierSigs.ml
+++ b/src/ModifierSigs.ml
@@ -1,4 +1,3 @@
-
 (** The parameters of an engine. *)
 module type Param =
 sig

--- a/src/ModifierSigs.ml
+++ b/src/ModifierSigs.ml
@@ -38,13 +38,15 @@ sig
   open P
   (** @closed *)
 
+  module type Handler = Handler with module P := P
+
   val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
   (** [modify modifier trie] runs the [modifier] on the [trie] and return the transformed trie.
 
       @param context The context sent to the effect handlers. If unspecified, effects come with {!constructor:None} as their context.
       @param prefix The prefix prepended to any path or prefix sent to the effect handlers. The default is the empty path ([Emp]). *)
 
-  module Run (H : Handler with module P := P) :
+  module Run (H : Handler) :
   sig
     val run : (unit -> 'a) -> 'a
     (** [run f h] initializes the engine and runs the thunk [f], using [h] to handle modifier effects. See {!type:handler}. *)
@@ -63,7 +65,7 @@ sig
     *)
   end
 
-  module Perform : Handler with module P := P
+  module Perform : Handler
   (** A handler that reperforms the effects. It can also be used to manually trigger the effects;
       for example, [Perform.not_found (Emp #< "a" #< "b")] will perform the [not_found] effect
       to be handled by the outer handler. *)

--- a/src/ModifierSigs.ml
+++ b/src/ModifierSigs.ml
@@ -44,7 +44,7 @@ sig
       @param context The context sent to the effect handlers. If unspecified, effects come with {!constructor:None} as their context.
       @param prefix The prefix prepended to any path or prefix sent to the effect handlers. The default is the empty path ([Emp]). *)
 
-  module Handle (H : Handler with module P := P) :
+  module Run (H : Handler with module P := P) :
   sig
     val run : (unit -> 'a) -> 'a
     (** [run f h] initializes the engine and runs the thunk [f], using [h] to handle modifier effects. See {!type:handler}. *)

--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -1,37 +1,10 @@
 open Bwd
 open BwdNotation
+open ScopeSigs
 
 module type Param = Modifier.Param
 module type Handler = Modifier.Handler
-
-module type S =
-sig
-  module P : Param
-  open P
-
-  exception Locked
-
-  val resolve : Trie.path -> (data * tag) option
-  val include_singleton : ?context_visible:context -> ?context_export:context -> Trie.path * (data * tag) -> unit
-  val include_subtree : ?context_visible:context -> ?context_export:context -> Trie.path * (data, tag) Trie.t -> unit
-  val import_subtree : ?context:context -> Trie.path * (data, tag) Trie.t -> unit
-  val modify_visible : ?context:context -> hook Language.t -> unit
-  val modify_export : ?context:context -> hook Language.t -> unit
-  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-  val export_visible : ?context:context -> hook Language.t -> unit
-  val get_export : unit -> (data, tag) Trie.t
-
-  val section : ?context_visible:context -> ?context_export:context -> Trie.path -> (unit -> 'a) -> 'a
-
-  module Handle (H : Handler with module P := P) :
-  sig
-    val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
-    val try_with : (unit -> 'a) -> 'a
-  end
-
-  module Perform : Handler with module P := P
-end
-
+module type S = S with module Language := Language
 
 module Make (P : Param) =
 struct

--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -5,14 +5,14 @@ open ScopeSigs
 module type Param = ScopeSigs.Param
 module type S = S with module Language := Language
 
-module Make (P : Param) : S with module P := P =
+module Make (Param : Param) : S with module Param := Param =
 struct
-  open P
-  module type Handler = ScopeSigs.Handler with module P := P
+  open Param
+  module type Handler = ScopeSigs.Handler with module Param := Param
 
   module Internal =
   struct
-    module Mod = Modifier.Make(P)
+    module Mod = Modifier.Make(Param)
 
     module M = Algaeff.Mutex.Make()
 

--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -84,9 +84,9 @@ struct
     unsafe_include_subtree ~context_visible ~context_export (p, export);
     ans
 
-  module Handle (H : Handler with module P := P) =
+  module Run (H : Handler with module P := P) =
   struct
-    module M = Mod.Handle (H)
+    module M = Mod.Run (H)
     let run ?(export_prefix=Emp) ?(init_visible=Trie.empty) f =
       M.run (fun () -> Internal.run ~export_prefix ~init_visible f)
     let try_with = M.try_with

--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -2,13 +2,13 @@ open Bwd
 open BwdNotation
 open ScopeSigs
 
-module type Param = Modifier.Param
-module type Handler = Modifier.Handler
+module type Param = ScopeSigs.Param
 module type S = S with module Language := Language
 
 module Make (P : Param) : S with module P := P =
 struct
   open P
+  module type Handler = ScopeSigs.Handler with module P := P
 
   module Internal =
   struct
@@ -84,7 +84,7 @@ struct
     unsafe_include_subtree ~context_visible ~context_export (p, export);
     ans
 
-  module Run (H : Handler with module P := P) =
+  module Run (H : Handler) =
   struct
     module M = Mod.Run (H)
     let run ?(export_prefix=Emp) ?(init_visible=Trie.empty) f =

--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -6,9 +6,8 @@ module type Param = Modifier.Param
 module type Handler = Modifier.Handler
 module type S = S with module Language := Language
 
-module Make (P : Param) =
+module Make (P : Param) : S with module P := P =
 struct
-  module P = P
   open P
 
   module Internal =

--- a/src/Scope.mli
+++ b/src/Scope.mli
@@ -3,4 +3,4 @@ open ScopeSigs
 
 module type Param = Param
 module type S = S with module Language := Language
-module Make (P : Param) : S with module P := P
+module Make (Param : Param) : S with module Param := Param

--- a/src/Scope.mli
+++ b/src/Scope.mli
@@ -2,7 +2,5 @@
 open ScopeSigs
 
 module type Param = Param
-module type Handler = Handler
 module type S = S with module Language := Language
-
 module Make (P : Param) : S with module P := P

--- a/src/Scope.mli
+++ b/src/Scope.mli
@@ -1,34 +1,8 @@
 (* See Yuujinchou.mli for documentation. *)
+open ScopeSigs
 
-module type Param = Modifier.Param
-module type Handler = Modifier.Handler
+module type Param = Param
+module type Handler = Handler
+module type S = S with module Language := Language
 
-module type S =
-sig
-  module P : Param
-  open P
-
-  exception Locked
-
-  val resolve : Trie.path -> (data * tag) option
-  val include_singleton : ?context_visible:context -> ?context_export:context -> Trie.path * (data * tag) -> unit
-  val include_subtree : ?context_visible:context -> ?context_export:context -> Trie.path * (data, tag) Trie.t -> unit
-  val import_subtree : ?context:context -> Trie.path * (data, tag) Trie.t -> unit
-  val modify_visible : ?context:context -> hook Language.t -> unit
-  val modify_export : ?context:context -> hook Language.t -> unit
-  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-  val export_visible : ?context:context -> hook Language.t -> unit
-  val get_export : unit -> (data, tag) Trie.t
-
-  val section : ?context_visible:context -> ?context_export:context -> Trie.path -> (unit -> 'a) -> 'a
-
-  module Handle (H : Handler with module P := P) :
-  sig
-    val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
-    val try_with : (unit -> 'a) -> 'a
-  end
-
-  module Perform : Handler with module P := P
-end
-
-module Make (P : Param) : S with module P = P
+module Make (P : Param) : S with module P := P

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -1,0 +1,118 @@
+module type Param = ModifierSigs.Param
+module type Handler = ModifierSigs.Handler
+
+module type S =
+sig
+  module Language : LanguageSigs.S
+
+  module P : Param
+  open P
+  (** @closed *)
+
+  exception Locked
+  (** The exception [Locked] is raised when an operation on a scope starts before another operation on the same scope is finished.
+      This could happen when the user, for example, calls {!val:modify_visible} and then calls {!val:modify_export} when handling the effects.
+
+      The principle is that one should not access any scope in its intermediate states, including looking up a name via {!val:resolve}.
+      Any attempt to do so will raise the exception [Locked].
+
+      Note: {!val:section} only locks the parent scope; the child scope is initially unlocked.
+  *)
+
+  (** {1 Basics} *)
+
+  val resolve : Trie.path -> (data * tag) option
+  (** [resolve p] looks up the name [p] in the current scope
+      and return the data associated with the binding. *)
+
+  val include_singleton : ?context_visible:context -> ?context_export:context -> Trie.path * (data * tag) -> unit
+  (** [include_singleton (p, x)] adds a new binding to both the visible
+      and export namespaces, where the binding is associating the data [x] to the path [p].
+      Conflicting names during the final merge will trigger the effect [shadow].
+
+      @param context_visible The context attached to the modifier effects when manipulating the visible namespace.
+      @param context_export The context attached to the modifier effects when manipulating the export namespace. *)
+
+  val include_subtree : ?context_visible:context -> ?context_export:context -> Trie.path * (data, tag) Trie.t -> unit
+  (** [include_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
+      both the visible and export namespaces. Conflicting names during the final merge
+      will trigger the effect [shadow].
+
+      @param context_visible The context attached to the modifier effects when manipulating the visible namespace.
+      @param context_export The context attached to the modifier effects when manipulating the export namespace. *)
+
+  val import_subtree : ?context:context -> Trie.path * (data, tag) Trie.t -> unit
+  (** [include_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
+      the visible namespace (while keeping the export namespace intact).
+      Conflicting names during the final merge will trigger the effect [Mod.Shadowing].
+
+      @param context The context attached to the modifier effects. *)
+
+  val modify_visible : ?context:context -> hook Language.t -> unit
+  (** [modify_visible m] modifies the visible namespace by
+      running the modifier [m] on it, using the internal modifier engine.
+
+      @param context The context attached to the modifier effects. *)
+
+  val modify_export : ?context:context -> hook Language.t -> unit
+  (** [modify_visible m] modifies the export namespace by
+      running the modifier [m] on it, using the internal modifier engine.
+
+      @param context The context attached to the modifier effects. *)
+
+  val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
+  (** Call the internal modifier engine directly on some trie. See {!val:Modifier.S.modify}.
+
+      This will not lock the current scope. *)
+
+  val export_visible : ?context:context -> hook Language.t -> unit
+  (** [export_visible m] runs the modifier [m] on the visible namespace,
+      and then merge the result into the export namespace.
+      Conflicting names during the final merge will trigger the effect [Mod.Shadowing].
+
+      @param context The context attached to the modifier effects. *)
+
+  val get_export : unit -> (data, tag) Trie.t
+  (** [get_export ()] returns the export namespace of the current scope. *)
+
+  (** {1 Sections} *)
+
+  val section : ?context_visible:context -> ?context_export:context -> Trie.path -> (unit -> 'a) -> 'a
+  (** [section p f] starts a new scope and runs the thunk [f] within the scope.
+      The child scope inherits the visible namespace from the parent, and its export namespace
+      will be prefixed with [p] and merged into both the visible and export namespaces
+      of the parent scope.
+
+      @param context_visible The context attached to the modifier effects
+      when merging the content of the section into its parent's visible namespace.
+      @param context_export The context attached to the modifier effects
+      when merging the content of the section into its parent's export namespace. *)
+
+  (** {1 Runners} *)
+
+  module Handle (H : Handler with module P := P) :
+  sig
+    val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
+    (** [run f h] initializes a scope and executes the thunk [f], using [h] to handle modifier effects.
+
+        @param export_prefix The additional global prefix prepended to the paths reported to effect handlers
+        originating from export namespaces. The default is the empty path ([Emp]).
+        This does not affect paths originating from visible namespaces.
+        @param init_visible The initial visible namespace. The default is the empty trie. *)
+
+    val try_with : (unit -> 'a) -> 'a
+    (** Execute the code and handles the internal modifier effects. This can be used to intercept
+        or reperform those effects; for example, the following function silences the [shadow] effects.
+        See also {!val:Modifier.S.try_with}.
+
+        {[
+          let silence_shadow f = try_with f {perform with shadow = fun _ _ _ y -> y}
+        ]}
+
+        Note that {!val:run} starts a fresh empty scope while [try_with] remains in the current scope.
+    *)
+  end
+
+  module Perform : Handler with module P := P
+  (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
+end

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -88,6 +88,10 @@ sig
       @param context_export The context attached to the modifier effects
       when merging the content of the section into its parent's export namespace. *)
 
+
+  module Perform : Handler with module P := P
+  (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
+
   (** {1 Runners} *)
 
   module Run (H : Handler with module P := P) :
@@ -106,13 +110,17 @@ sig
         See also {!val:Modifier.S.try_with}.
 
         {[
-          let silence_shadow f = try_with f {perform with shadow = fun _ _ _ y -> y}
+          module H =
+          struct
+            include Perform
+            let shadow _ _ _ y = y
+          end
+
+          let silence_shadow f = let module R = Run (H) in R.try_with f
         ]}
 
         Note that {!val:run} starts a fresh empty scope while [try_with] remains in the current scope.
     *)
   end
 
-  module Perform : Handler with module P := P
-  (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
 end

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -9,6 +9,8 @@ sig
   open P
   (** @closed *)
 
+  module type Handler = Handler with module P := P
+
   exception Locked
   (** The exception [Locked] is raised when an operation on a scope starts before another operation on the same scope is finished.
       This could happen when the user, for example, calls {!val:modify_visible} and then calls {!val:modify_export} when handling the effects.
@@ -89,12 +91,12 @@ sig
       when merging the content of the section into its parent's export namespace. *)
 
 
-  module Perform : Handler with module P := P
+  module Perform : Handler
   (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
 
   (** {1 Runners} *)
 
-  module Run (H : Handler with module P := P) :
+  module Run (H : Handler) :
   sig
     val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
     (** [run f h] initializes a scope and executes the thunk [f], using [h] to handle modifier effects.

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -5,11 +5,10 @@ module type S =
 sig
   module Language : LanguageSigs.S
 
-  module P : Param
-  open P
-  (** @closed *)
+  module Param : Param
+  open Param
 
-  module type Handler = Handler with module P := P
+  module type Handler = Handler with module Param := Param
 
   exception Locked
   (** The exception [Locked] is raised when an operation on a scope starts before another operation on the same scope is finished.
@@ -92,7 +91,7 @@ sig
 
 
   module Perform : Handler
-  (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
+  (** A handler that reperforms the internal modifier effects. See {!module:Modifier.S.Perform}. *)
 
   (** {1 Runners} *)
 
@@ -109,7 +108,7 @@ sig
     val try_with : (unit -> 'a) -> 'a
     (** Execute the code and handles the internal modifier effects. This can be used to intercept
         or reperform those effects; for example, the following function silences the [shadow] effects.
-        See also {!val:Modifier.S.try_with}.
+        See also {!val:Modifier.S.Run.try_with}.
 
         {[
           module H =

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -89,10 +89,6 @@ sig
       @param context_export The context attached to the modifier effects
       when merging the content of the section into its parent's export namespace. *)
 
-
-  module Perform : Handler
-  (** A handler that reperforms the internal modifier effects. See {!module:Modifier.S.Perform}. *)
-
   (** {1 Runners} *)
 
   module Run (H : Handler) :
@@ -124,4 +120,6 @@ sig
     *)
   end
 
+  module Perform : Handler
+  (** A handler that reperforms the internal modifier effects. See {!module:Modifier.S.Perform}. *)
 end

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -90,7 +90,7 @@ sig
 
   (** {1 Runners} *)
 
-  module Handle (H : Handler with module P := P) :
+  module Run (H : Handler with module P := P) :
   sig
     val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
     (** [run f h] initializes a scope and executes the thunk [f], using [h] to handle modifier effects.

--- a/src/Yuujinchou.ml
+++ b/src/Yuujinchou.ml
@@ -3,6 +3,7 @@ struct
   include Trie
   module Untagged = UntaggedTrie
 end
+
 module Language = Language
 module Modifier = Modifier
 module Scope = Scope

--- a/src/Yuujinchou.mli
+++ b/src/Yuujinchou.mli
@@ -21,7 +21,7 @@ sig
   module type S = ModifierSigs.S with module Language := Language
 
   (** The functor to generate an engine. *)
-  module Make (P : ModifierSigs.Param) : S with module P := P
+  module Make (Param : ModifierSigs.Param) : S with module Param := Param
 end
 
 (** The {!module:Scope} module implements lexical scoping based on {!module:Modifier}. *)
@@ -33,6 +33,6 @@ sig
   (** The signature of scoping effects. *)
   module type S = ScopeSigs.S with module Language := Language
 
-  module Make (P : Param) : S with module P := P
+  module Make (Param : Param) : S with module Param := Param
   (** The functor to generate a module for scoping effects. *)
 end

--- a/src/Yuujinchou.mli
+++ b/src/Yuujinchou.mli
@@ -9,281 +9,36 @@ module Trie : sig
 end
 
 (** The {!module:Language} module defines the language of modifiers. *)
-module Language :
-sig
-  (** {1 Types} *)
-
-  (** The abstract type of modifiers, parametrized by the type of hook labels. See {!val:hook} for hook labels.
-
-      Construct terms using builders in {!module:Language} and execute them using {!val:Modifier.S.modify}. *)
-  type 'hook t
-
-  (** Checking equality. *)
-  val equal : ('hook -> 'hook -> bool) -> 'hook t -> 'hook t -> bool
-
-  (** {1 Modifier Builders} *)
-
-  (** {2 Basics} *)
-
-  (** [any] keeps the content of the current tree. It is an error if the tree is empty (no name to match).
-      To avoid the emptiness checking, use the identity modifier {!val:seq}[ []].
-      This is equivalent to {!val:only}[ []]. *)
-  val any : 'hook t
-
-  (** [only path] keeps the subtree rooted at [path]. It is an error if the subtree was empty. *)
-  val only : Trie.path -> 'hook t
-
-  (** [in_ path m] runs the modifier [m] on the subtree rooted at [path]. Bindings outside the subtree are kept intact. For example, [in_ ["x"] ]{!val:any} will keep [y] (if existing), while {!val:only}[ ["x"]] will drop [y]. *)
-  val in_ : Trie.path -> 'hook t -> 'hook t
-
-  (** {2 Negation} *)
-
-  (** [none] drops everything. It is an error if the tree was already empty (nothing to drop).
-      To avid the emptiness checking, use the empty modifier {!val:union}[ []]. *)
-  val none : 'hook t
-
-  (** [except p] drops the subtree rooted at [p]. It is an error if there was nothing in the subtree. This is equivalent to {!val:in_}[ p ]{!val:none}. *)
-  val except : Trie.path -> 'hook t
-
-  (** {2 Renaming} *)
-
-  (** [renaming path path'] relocates the subtree rooted at [path] to [path']. The existing bindings at [path'] (if any) will be dropped.
-      It is an error if the subtree was empty (nothing to move). *)
-  val renaming : Trie.path -> Trie.path -> 'hook t
-
-  (** {2 Sequencing} *)
-
-  (** [seq [m0; m1; m2; ...; mn]] runs the modifiers [m0], [m1], [m2], ..., [mn] in order.
-      In particular, [seq []] is the identity modifier. *)
-  val seq : 'hook t list -> 'hook t
-
-  (** {2 Union} *)
-
-  (** [union [m0; m1; m2; ...; mn]] calculates the union of the results of individual modifiers [m0], [m1], [m2], ..., [mn].
-      In particular, [union []] is the empty modifier.
-      The {!field:Modifier.shadow} effect will be performed to resolve name conflicts,
-      with an intention for results of a modifier to shadow those of previous ones. *)
-  val union : 'hook t list -> 'hook t
-
-  (** {2 Custom Hooks} *)
-
-  (** [hook h] applies the hook labelled [h] to the entire trie
-      by performing the {!field:Modifier.hook} effect. *)
-  val hook : 'hook -> 'hook t
-
-  (** {2 Ugly Printing} *)
-
-  (** [dump dump_hook m] dumps the internal representation of [m] for debugging,
-      where [dump_hook] is the ugly printer for hook labels (see {!val:hook}). *)
-  val dump : (Format.formatter -> 'hook -> unit) -> Format.formatter -> 'hook t -> unit [@@ocaml.toplevel_printer]
-end
+module Language : LanguageSigs.S
 
 (** The {!module:Modifier} module implements the engine running the modifiers of type {!type:Language.t}. *)
 module Modifier :
 sig
-
-  (** The parameters of an engine. *)
-  module type Param =
-  sig
-    (** The type of data held by the bindings. The difference between data and tags is that the data will survive the efficient retagging. See {!val:Trie.retag}. *)
-    type data
-
-    (** The type of tags attached to the bindings. The difference between data and tags is that tags can be efficiently reset. See {!val:Trie.retag}. *)
-    type tag
-
-    (** The type of modifier hook labels. This is for extending the modifier language. *)
-    type hook
-
-    (** The type of contexts passed to each call of {!val:Modifier.S.modify} for the effect handler to distinguish different function calls. *)
-    type context
-  end
-
+  (** The parameters of this module. *)
+  module type Param = ModifierSigs.Param
 
   (** The type of effect handlers used in this module. *)
-  module type Handler =
-  sig
-    module P : Param
-    open P
-
-    val not_found : context option -> Trie.bwd_path -> unit
-    (** [not_found ctx prefix] is called when the engine expects at least one binding within the subtree at [prefix] but could not find any, where [ctx] is the context passed to {!val:S.modify}. Modifiers such as {!val:Language.any}, {!val:Language.only}, {!val:Language.none}, and a few other modifiers expect at least one matching binding. For example, the modifier {!val:Language.except}[ ["x"; "y"]] expects that there was already something under the subtree at [x.y]. If there were actually no names with the prefix [x.y], then the modifier will trigger this effect with [prefix] being [Emp #< "x" #< "y"]. *)
-
-
-    val shadow : context option -> Trie.bwd_path -> data * tag -> data * tag -> data * tag
-    (** [shadow ctx path x y] is called when item [y] is being assigned to [path] but [x] is already bound at [path], where [ctx] is the context passed to {!val:S.modify}. Modifiers such as {!val:Language.renaming} and {!val:Language.union} could lead to bindings having the same name, and when that happens, this function is called to resolve the conflicting bindings. To implement silent shadowing, one can simply return item [y]. One can also employ a more sophisticated strategy to implement type-directed disambiguation. *)
-
-
-    val hook : context option -> Trie.bwd_path -> hook -> (data, tag) Trie.t -> (data, tag) Trie.t
-    (** [hook prefix id input] is called when processing the modifiers created by {!val:Language.hook}, where [ctx] is the context passed to {!val:S.modify}. When the engine encounters the modifier {!val:Language.hook}[ id] while handling the subtree [input] at [prefix], it will call [hook prefix id input] and replace the existing subtree [input] with the return value. *)
-
-  end
+  module type Handler = ModifierSigs.Handler
 
   (** The signature of the engine. *)
-  module type S =
-  sig
-    module P : Param
-    open P
-    (** @closed *)
-
-    val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-    (** [modify modifier trie] runs the [modifier] on the [trie] and return the transformed trie.
-
-        @param context The context sent to the effect handlers. If unspecified, effects come with {!constructor:None} as their context.
-        @param prefix The prefix prepended to any path or prefix sent to the effect handlers. The default is the empty path ([Emp]). *)
-
-    module Handle (H : Handler with module P := P) :
-    sig
-      val run : (unit -> 'a) -> 'a
-      (** [run f h] initializes the engine and runs the thunk [f], using [h] to handle modifier effects. See {!type:handler}. *)
-
-      val try_with : (unit -> 'a) -> 'a
-      (** [try_with f h] runs the thunk [f], using [h] to handle the intercepted modifier effects. See {!type:handler}.
-
-          Currently, [try_with] is an alias of {!val:run}, but [try_with] is intended to use within {!val:run} to intercept effects,
-          while {!val:run} is intended to be at the outermost layer to handle effects. That is, the following is the expected program structure:
-          {[
-            run @@ fun () ->
-            (* code *)
-            try_with f
-            (* more code *)
-          ]}
-      *)
-    end
-
-    module Perform : Handler with module P := P
-    (** A handler that reperforms the effects. It can also be used to manually trigger the effects;
-        for example, [perform.not_found (Emp #< "a" #< "b")] will perform the [not_found] effect
-        to be handled by the outer handler. *)
-  end
+  module type S = ModifierSigs.S with module Language := Language
 
   (** The functor to generate an engine. *)
-  module Make (P : Param) : S with module P = P
+  module Make (P : ModifierSigs.Param) : S with module P := P
 end
 
 (** The {!module:Scope} module implements lexical scoping based on {!module:Modifier}. *)
 module Scope :
 sig
   (** The parameters of scoping effects. *)
-  module type Param = Modifier.Param
+  module type Param = ScopeSigs.Param
 
   (** The type of effect handlers used in this module. *)
-  module type Handler = Modifier.Handler
+  module type Handler = ScopeSigs.Handler
 
   (** The signature of scoping effects. *)
-  module type S =
-  sig
-    module P : Param
-    open P
-    (** @closed *)
+  module type S = ScopeSigs.S with module Language := Language
 
-    exception Locked
-    (** The exception [Locked] is raised when an operation on a scope starts before another operation on the same scope is finished.
-        This could happen when the user, for example, calls {!val:modify_visible} and then calls {!val:modify_export} when handling the effects.
-
-        The principle is that one should not access any scope in its intermediate states, including looking up a name via {!val:resolve}.
-        Any attempt to do so will raise the exception [Locked].
-
-        Note: {!val:section} only locks the parent scope; the child scope is initially unlocked.
-    *)
-
-    (** {1 Basics} *)
-
-    val resolve : Trie.path -> (data * tag) option
-    (** [resolve p] looks up the name [p] in the current scope
-        and return the data associated with the binding. *)
-
-    val include_singleton : ?context_visible:context -> ?context_export:context -> Trie.path * (data * tag) -> unit
-    (** [include_singleton (p, x)] adds a new binding to both the visible
-        and export namespaces, where the binding is associating the data [x] to the path [p].
-        Conflicting names during the final merge will trigger the effect [shadow].
-
-        @param context_visible The context attached to the modifier effects when manipulating the visible namespace.
-        @param context_export The context attached to the modifier effects when manipulating the export namespace. *)
-
-    val include_subtree : ?context_visible:context -> ?context_export:context -> Trie.path * (data, tag) Trie.t -> unit
-    (** [include_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
-        both the visible and export namespaces. Conflicting names during the final merge
-        will trigger the effect [shadow].
-
-        @param context_visible The context attached to the modifier effects when manipulating the visible namespace.
-        @param context_export The context attached to the modifier effects when manipulating the export namespace. *)
-
-    val import_subtree : ?context:context -> Trie.path * (data, tag) Trie.t -> unit
-    (** [include_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
-        the visible namespace (while keeping the export namespace intact).
-        Conflicting names during the final merge will trigger the effect [Mod.Shadowing].
-
-        @param context The context attached to the modifier effects. *)
-
-    val modify_visible : ?context:context -> hook Language.t -> unit
-    (** [modify_visible m] modifies the visible namespace by
-        running the modifier [m] on it, using the internal modifier engine.
-
-        @param context The context attached to the modifier effects. *)
-
-    val modify_export : ?context:context -> hook Language.t -> unit
-    (** [modify_visible m] modifies the export namespace by
-        running the modifier [m] on it, using the internal modifier engine.
-
-        @param context The context attached to the modifier effects. *)
-
-    val modify : ?context:context -> ?prefix:Trie.bwd_path -> hook Language.t -> (data, tag) Trie.t -> (data, tag) Trie.t
-    (** Call the internal modifier engine directly on some trie. See {!val:Modifier.S.modify}.
-
-        This will not lock the current scope. *)
-
-    val export_visible : ?context:context -> hook Language.t -> unit
-    (** [export_visible m] runs the modifier [m] on the visible namespace,
-        and then merge the result into the export namespace.
-        Conflicting names during the final merge will trigger the effect [Mod.Shadowing].
-
-        @param context The context attached to the modifier effects. *)
-
-    val get_export : unit -> (data, tag) Trie.t
-    (** [get_export ()] returns the export namespace of the current scope. *)
-
-    (** {1 Sections} *)
-
-    val section : ?context_visible:context -> ?context_export:context -> Trie.path -> (unit -> 'a) -> 'a
-    (** [section p f] starts a new scope and runs the thunk [f] within the scope.
-        The child scope inherits the visible namespace from the parent, and its export namespace
-        will be prefixed with [p] and merged into both the visible and export namespaces
-        of the parent scope.
-
-        @param context_visible The context attached to the modifier effects
-        when merging the content of the section into its parent's visible namespace.
-        @param context_export The context attached to the modifier effects
-        when merging the content of the section into its parent's export namespace. *)
-
-    (** {1 Runners} *)
-
-    module Handle (H : Handler with module P := P) :
-    sig
-      val run : ?export_prefix:Trie.bwd_path -> ?init_visible:(data, tag) Trie.t -> (unit -> 'a) -> 'a
-      (** [run f h] initializes a scope and executes the thunk [f], using [h] to handle modifier effects.
-
-          @param export_prefix The additional global prefix prepended to the paths reported to effect handlers
-          originating from export namespaces. The default is the empty path ([Emp]).
-          This does not affect paths originating from visible namespaces.
-          @param init_visible The initial visible namespace. The default is the empty trie. *)
-
-      val try_with : (unit -> 'a) -> 'a
-      (** Execute the code and handles the internal modifier effects. This can be used to intercept
-          or reperform those effects; for example, the following function silences the [shadow] effects.
-          See also {!val:Modifier.S.try_with}.
-
-          {[
-            let silence_shadow f = try_with f {perform with shadow = fun _ _ _ y -> y}
-          ]}
-
-          Note that {!val:run} starts a fresh empty scope while [try_with] remains in the current scope.
-      *)
-    end
-
-    module Perform : Handler with module P := P
-    (** A handler that reperforms the internal modifier effects. See {!val:Modifier.S.Perform}. *)
-  end
-
-  module Make (P : Param) : S with module P = P
+  module Make (P : Param) : S with module P := P
   (** The functor to generate a module for scoping effects. *)
 end

--- a/src/Yuujinchou.mli
+++ b/src/Yuujinchou.mli
@@ -17,9 +17,6 @@ sig
   (** The parameters of this module. *)
   module type Param = ModifierSigs.Param
 
-  (** The type of effect handlers used in this module. *)
-  module type Handler = ModifierSigs.Handler
-
   (** The signature of the engine. *)
   module type S = ModifierSigs.S with module Language := Language
 
@@ -32,9 +29,6 @@ module Scope :
 sig
   (** The parameters of scoping effects. *)
   module type Param = ScopeSigs.Param
-
-  (** The type of effect handlers used in this module. *)
-  module type Handler = ScopeSigs.Handler
 
   (** The signature of scoping effects. *)
   module type S = ScopeSigs.S with module Language := Language

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -27,52 +27,62 @@ module S = Scope.Make (struct
   end)
 
 (* Handle scoping effects *)
-let handler : _ Scope.handler =
+module Handler =
+struct
   let pp_path fmt =
     function
     | Emp -> Format.pp_print_string fmt "(root)"
     | path -> Format.pp_print_string fmt @@ String.concat "." (Bwd.to_list path)
-  in
+
   let pp_context fmt =
     function
     | Some `Visible -> Format.pp_print_string fmt " in the visible namespace"
     | Some `Export -> Format.pp_print_string fmt " in the export namespace"
     | None -> ()
-  in
+
   let pp_item fmt =
     function
     | (x, `Imported) -> Format.fprintf fmt "%i (imported)" x
     | (x, `Local) -> Format.fprintf fmt "%i (local)" x
-  in
-  { not_found =
-      (fun context prefix ->
-         Format.printf
-           "[Warning] Could not find any data within the subtree at %a%a.@."
-           pp_path prefix pp_context context);
-    shadow =
-      (fun context path x y ->
-         Format.printf
-           "[Warning] Data %a assigned at %a was shadowed by data %a%a.@."
-           pp_item x
-           pp_path path
-           pp_item y
-           pp_context context;
-         y);
-    hook =
-      (fun context prefix hook input ->
-         match hook with
-         | Print ->
-           Format.printf "@[<v 2>[Info] Got the following bindings at %a%a:@;"
-             pp_path prefix pp_context context;
-           Trie.iter
-             (fun path x ->
-                Format.printf "%a => %a@;" pp_path path pp_item x)
-             input;
-           Format.printf "@]@.";
-           input)}
+
+  let not_found context prefix =
+    Format.printf
+      "[Warning] Could not find any data within the subtree at %a%a.@."
+      pp_path prefix pp_context context
+
+  let shadow context path x y =
+    Format.printf
+      "[Warning] Data %a assigned at %a was shadowed by data %a%a.@."
+      pp_item x
+      pp_path path
+      pp_item y
+      pp_context context;
+    y
+
+  let hook context prefix hook input =
+    match hook with
+    | Print ->
+      Format.printf "@[<v 2>[Info] Got the following bindings at %a%a:@;"
+        pp_path prefix pp_context context;
+      Trie.iter
+        (fun path x ->
+           Format.printf "%a => %a@;" pp_path path pp_item x)
+        input;
+      Format.printf "@]@.";
+      input
+end
+
+module SilentHandler =
+struct
+  include Handler
+  let shadow _ _ _ y = y
+end
+
 
 (* Mute the [shadow] effects. *)
-let silence_shadow f = S.try_with f {S.perform with shadow = fun _ _ _ y -> y}
+let silence_shadow f =
+  let module SH = S.Handle (SilentHandler) in
+  SH.try_with f
 
 (* The interpreter *)
 let rec interpret_decl : decl -> unit =
@@ -93,7 +103,8 @@ let rec interpret_decl : decl -> unit =
     S.section p @@ fun () -> List.iter interpret_decl sec
 
 let interpret (prog : program) =
-  S.run (fun () -> List.iter interpret_decl prog) handler
+  let module SH = S.Handle (Handler) in
+  SH.run (fun () -> List.iter interpret_decl prog)
 
 (* Some code in action *)
 let () = interpret [

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -81,8 +81,8 @@ end
 
 (* Mute the [shadow] effects. *)
 let silence_shadow f =
-  let module SH = S.Handle (SilentHandler) in
-  SH.try_with f
+  let module R = S.Run (SilentHandler) in
+  R.try_with f
 
 (* The interpreter *)
 let rec interpret_decl : decl -> unit =
@@ -103,8 +103,9 @@ let rec interpret_decl : decl -> unit =
     S.section p @@ fun () -> List.iter interpret_decl sec
 
 let interpret (prog : program) =
-  let module SH = S.Handle (Handler) in
-  SH.run (fun () -> List.iter interpret_decl prog)
+  let module R = S.Run (Handler) in
+  R.run @@ fun () ->
+  List.iter interpret_decl prog
 
 (* Some code in action *)
 let () = interpret [

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -16,15 +16,19 @@ type decl =
   | Export of Trie.path
   (* section *)
   | Section of Trie.path * decl list
+
 type program = decl list
 
-(* Specialzed Scope module with Data.t *)
-module S = Scope.Make (struct
-    type data = int
-    type tag = [`Imported | `Local]
-    type hook = modifier_cmd
-    type context = [`Visible | `Export]
-  end)
+module P =
+struct
+  type data = int
+  type tag = [`Imported | `Local]
+  type hook = modifier_cmd
+  type context = [`Visible | `Export]
+end
+
+(* Specialized Scope module *)
+module S = Scope.Make (P)
 
 (* Handle scoping effects *)
 module H =

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -27,7 +27,7 @@ module S = Scope.Make (struct
   end)
 
 (* Handle scoping effects *)
-module Handler =
+module H =
 struct
   let pp_path fmt =
     function
@@ -72,16 +72,15 @@ struct
       input
 end
 
-module SilentHandler =
+module SilentH =
 struct
-  include Handler
+  include H
   let shadow _ _ _ y = y
 end
 
-
 (* Mute the [shadow] effects. *)
 let silence_shadow f =
-  let module R = S.Run (SilentHandler) in
+  let module R = S.Run (SilentH) in
   R.try_with f
 
 (* The interpreter *)
@@ -103,7 +102,7 @@ let rec interpret_decl : decl -> unit =
     S.section p @@ fun () -> List.iter interpret_decl sec
 
 let interpret (prog : program) =
-  let module R = S.Run (Handler) in
+  let module R = S.Run (H) in
   R.run @@ fun () ->
   List.iter interpret_decl prog
 

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -31,7 +31,7 @@ end
 module S = Scope.Make (P)
 
 (* Handle scoping effects *)
-module H =
+module H : S.Handler =
 struct
   let pp_path fmt =
     function
@@ -76,9 +76,9 @@ struct
       input
 end
 
-module SilentH =
+module SilentH : S.Handler =
 struct
-  include H
+  include S.Perform
   let shadow _ _ _ y = y
 end
 

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -42,7 +42,7 @@ struct
 end
 
 let wrap f =
-  let module R = M.Handle (WrapHandler) in
+  let module R = M.Run (WrapHandler) in
   R.run f
 
 let wrap_error f = fun () -> wrap @@ fun () -> ignore (f ())

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -33,11 +33,17 @@ type empty = |
 module M = Modifier.Make (struct type nonrec data = data type tag = unit type hook = empty type context = empty end)
 
 exception WrappedBindingNotFound of Trie.bwd_path
+
+module WrapHandler =
+struct
+  let not_found _ prefix = raise @@ WrappedBindingNotFound prefix
+  let shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
+  let hook _ _ = function (_ : empty) -> .
+end
+
 let wrap f =
-  M.run f
-    { not_found = (fun _ prefix -> raise @@ WrappedBindingNotFound prefix);
-      shadow = (fun _ path (x, ()) (y, ()) -> U (path, x, y), ());
-      hook = (fun _ _ -> function _ -> .) }
+  let module R = M.Handle (WrapHandler) in
+  R.run f
 
 let wrap_error f = fun () -> wrap @@ fun () -> ignore (f ())
 

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -34,16 +34,14 @@ module M = Modifier.Make (struct type nonrec data = data type tag = unit type ho
 
 exception WrappedBindingNotFound of Trie.bwd_path
 
-module WrapHandler =
+module WrapH =
 struct
   let not_found _ prefix = raise @@ WrappedBindingNotFound prefix
   let shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
   let hook _ _ = function (_ : empty) -> .
 end
 
-let wrap f =
-  let module R = M.Run (WrapHandler) in
-  R.run f
+let wrap f = let module WrapR = M.Run (WrapH) in WrapR.run f
 
 let wrap_error f = fun () -> wrap @@ fun () -> ignore (f ())
 


### PR DESCRIPTION
This pull request contains two changes:

1. Replace the `handler` records with modules. I found (experimentally) while hacking `algaett` that it is a lot less painful to program the handlers with modules than it is to write out the records. Features like `include` and `open` are useful, and I would not discount reducing the stress of being several parenthesis/brace delimiter levels into a gnarly piece of code.

2. I have refactored the modules so that the main signatures are declared (and documented) just once. This removes a lot of duplication that is annoying when refactoring code. It also means that if documentation is generated for the private/internal modules, the documentation comments will appear for these as well. Sometimes we wish to expose a different public interface than the private interface (but I didn't notice that in this library); that too can be incorporated, through judicious use of `include`.

Let me know if you have any feedback about these changes, or if you don't like it for some reason. Thanks!