### PR TITLE
refactor!: use first-class modules

### DIFF
--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -9,6 +9,7 @@ module Make (Param : Param) : S with module Param := Param =
 struct
   open Param
   module type Handler = ScopeSigs.Handler with module Param := Param
+  type handler = (module Handler)
 
   module Internal =
   struct
@@ -84,13 +85,11 @@ struct
     unsafe_include_subtree ~context_visible ~context_export (p, export);
     ans
 
-  module Run (H : Handler) =
-  struct
-    module M = Mod.Run (H)
-    let run ?(export_prefix=Emp) ?(init_visible=Trie.empty) f =
-      M.run (fun () -> Internal.run ~export_prefix ~init_visible f)
-    let try_with = M.try_with
-  end
+  let run ?(export_prefix=Emp) ?(init_visible=Trie.empty) h f =
+    Mod.run h @@ fun () -> Internal.run ~export_prefix ~init_visible f
+
+  let try_with = Mod.try_with
 
   module Perform = Mod.Perform
+  let perform = Mod.perform
 end

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -32,16 +32,16 @@ let data : data Alcotest.testable =
 type empty = |
 module M = Modifier.Make (struct type nonrec data = data type tag = unit type hook = empty type context = empty end)
 
-exception WrappedBindingNotFound of Trie.bwd_path
+exception Wrapped_not_found of Trie.bwd_path
 
-module WrapH =
-struct
-  let not_found _ prefix = raise @@ WrappedBindingNotFound prefix
-  let shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
-  let hook _ _ = function (_ : empty) -> .
-end
+let wrapper : M.handler =
+  (module struct
+    let not_found _ prefix = raise @@ Wrapped_not_found prefix
+    let shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
+    let hook _ _ = function (_ : empty) -> .
+  end)
 
-let wrap f = let module WrapR = M.Run (WrapH) in WrapR.run f
+let wrap f = M.run wrapper f
 
 let wrap_error f = fun () -> wrap @@ fun () -> ignore (f ())
 
@@ -59,7 +59,7 @@ let test_none_2 () =
 
 let test_none_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound Emp)
+    (Wrapped_not_found Emp)
     (wrap_error @@ fun () -> M.modify none Trie.empty)
 
 let test_any_1 () =
@@ -74,7 +74,7 @@ let test_any_2 () =
 
 let test_any_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound Emp)
+    (Wrapped_not_found Emp)
     (wrap_error @@ fun () -> M.modify any Trie.empty)
 
 let test_any_4 () =
@@ -95,7 +95,7 @@ let test_only_2 () =
 
 let test_only_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound (Emp #< "x" #< "y"))
+    (Wrapped_not_found (Emp #< "x" #< "y"))
     (wrap_error @@ fun () -> M.modify (only ["x"; "y"]) Trie.empty)
 
 let test_only_4 () =
@@ -116,7 +116,7 @@ let test_except_2 () =
 
 let test_except_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound (Emp #< "x" #< "y"))
+    (Wrapped_not_found (Emp #< "x" #< "y"))
     (wrap_error @@ fun () -> M.modify (except ["x"; "y"]) Trie.empty)
 
 let test_in_1 () =
@@ -131,7 +131,7 @@ let test_in_2 () =
 
 let test_in_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound (Emp #< "x"))
+    (Wrapped_not_found (Emp #< "x"))
     (wrap_error @@ fun () -> M.modify (in_ ["x"] any) Trie.empty)
 
 let test_in_4 () =
@@ -152,7 +152,7 @@ let test_renaming_2 () =
 
 let test_renaming_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound (Emp #< "x"))
+    (Wrapped_not_found (Emp #< "x"))
     (wrap_error @@ fun () -> M.modify (renaming ["x"] ["z"]) Trie.empty)
 
 let test_renaming_4 () =
@@ -181,17 +181,17 @@ let test_seq_1 () =
 
 let test_seq_2 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound Emp)
+    (Wrapped_not_found Emp)
     (wrap_error @@ fun () -> M.modify (seq [none; any]) (of_list [["x"; "y"], N 10; ["x"; "x"], N 20; ["y"], N 30]))
 
 let test_seq_3 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound Emp)
+    (Wrapped_not_found Emp)
     (wrap_error @@ fun () -> M.modify (seq [none; none]) Trie.empty)
 
 let test_seq_4 () =
   Alcotest.check_raises "error"
-    (WrappedBindingNotFound (Emp #< "x"))
+    (Wrapped_not_found (Emp #< "x"))
     (wrap_error @@ fun () -> M.modify (seq [renaming ["x"] ["z"]; only ["x"]]) (of_list [["x"], N 10; ["y"], N 20]))
 
 let test_seq_5 () =


### PR DESCRIPTION
**This is a breaking change.**

There are subtle semantic differences between `run` and `try_with`, though they share a very similar interface. The current functorial interface is not ideal because for a fixed set of handlers usually only makes sense for either `run` or `try_with`, but not both. (For example, the set of handlers that silences the `shadow` effects make sense with `try_with` but not with `run`.) The current design makes it look like both functions can be used for any set of handlers, which is misleading. Thus, we should at least have separate functors for `run` and `try_with` like this:
```ocaml
module Handler = struct ... end
let () = let module R = M.Run (Handler) in R.run @@ fun () -> ...

module Interceptor = struct ... end
let () = let module T = M.TryWith (Interceptor) in T.try_with @@ fun () -> ...
```
At this point I feel we could try first-class modules to reduce boilerplate. The new interface after this PR would be
```ocaml
let handler : M.handler = (module struct ... end)
let () = M.run handler @@ fun () -> ...

let interceptor : M.handler = (module struct ... end)
let () = M.try_with interceptor @@ fun () -> ...
```
