### PR TITLE
fix: use labelled arguments instead of functors

### DIFF
--- a/src/Modifier.mli
+++ b/src/Modifier.mli
@@ -1,6 +1,6 @@
 (* See Yuujinchou.mli for documentation. *)
 module type Param = ModifierSigs.Param
-module type Handler = ModifierSigs.Handler
+module type Perform = ModifierSigs.Perform
 module type S = ModifierSigs.S with module Language := Language
 
 module Make (Param : Param) : S with module Param := Param

--- a/src/Scope.mli
+++ b/src/Scope.mli
@@ -1,6 +1,6 @@
 (* See Yuujinchou.mli for documentation. *)
 module type Param = ScopeSigs.Param
-module type Handler = ScopeSigs.Handler
+module type Perform = ScopeSigs.Perform
 module type S = ScopeSigs.S with module Language := Language
 module Make (Param : Param) (Modifier : Modifier.S with module Param := Param)
   : S with module Param := Param

--- a/src/Yuujinchou.mli
+++ b/src/Yuujinchou.mli
@@ -18,7 +18,7 @@ sig
   module type Param = ModifierSigs.Param
 
   (** The handler module type. *)
-  module type Handler = ModifierSigs.Handler
+  module type Perform = ModifierSigs.Perform
 
   (** The signature of the engine. *)
   module type S = ModifierSigs.S with module Language := Language
@@ -34,7 +34,7 @@ sig
   module type Param = ScopeSigs.Param
 
   (** The handler module type. *)
-  module type Handler = ModifierSigs.Handler
+  module type Perform = ModifierSigs.Perform
 
   (** The signature of scoping effects. *)
   module type S = ScopeSigs.S with module Language := Language

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -34,14 +34,12 @@ module M = Modifier.Make (struct type nonrec data = data type tag = unit type ho
 
 exception WrappedBindingNotFound of Trie.bwd_path
 
-module WrapH =
-struct
+let wrap f =
   let not_found _ prefix = raise @@ WrappedBindingNotFound prefix
-  let shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
-  let hook _ _ = function (_ : empty) -> .
-end
-
-let wrap f = let module WrapR = M.Run (WrapH) in WrapR.run f
+  and shadow _ path (x, ()) (y, ()) = U (path, x, y), ()
+  and hook _ _ = function (_ : empty) -> .
+  in
+  M.run ~not_found ~shadow ~hook f
 
 let wrap_error f = fun () -> wrap @@ fun () -> ignore (f ())
 


### PR DESCRIPTION
This PR implements the Thought of using labelled arguments.

The main thing I am not sure of is that handlers are optional to `Modifier.run` in this PR---by default, it would simply ignore all the algebraic effects. (That is, shadowing will be silent, "name not found" will be ignored, and hooks are skipped.) Is it a good design to allow users to omit those handlers and default to the "silencing" handlers? The obvious alternative is to make them mandatory.