### PR TITLE
feat(Scope): improve the support of local bindings

### DIFF
--- a/src/Scope.ml
+++ b/src/Scope.ml
@@ -50,7 +50,9 @@ struct
     M.exclusively @@ fun () -> S.modify @@ fun s ->
     {s with export = Mod.modify ?context ~prefix:(export_prefix()) m s.export}
 
-  let modify = Mod.modify
+  let modify_standalone = Mod.modify
+
+  let modify = modify_standalone [@@ocaml.alert deprecated "Use modify_standalone"]
 
   let export_visible ?context m =
     M.exclusively @@ fun () -> S.modify @@ fun s ->
@@ -63,6 +65,10 @@ struct
     M.exclusively @@ fun () -> S.modify @@ fun s ->
     { visible = Trie.union_singleton ~prefix:Emp (Mod.Perform.shadow context_visible) s.visible (path, x);
       export = Trie.union_singleton ~prefix:(export_prefix()) (Mod.Perform.shadow context_export) s.export (path, x) }
+
+  let import_singleton ?context (path, x) =
+    M.exclusively @@ fun () -> S.modify @@ fun s ->
+    { s with visible = Trie.union_singleton ~prefix:Emp (Mod.Perform.shadow context) s.visible (path, x) }
 
   let unsafe_include_subtree ~context_visible ~context_export (path, ns) =
     S.modify @@ fun s ->

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -31,7 +31,7 @@ sig
   val include_singleton : ?context_visible:context -> ?context_export:context -> Trie.path * (data * tag) -> unit
   (** [include_singleton (p, x)] adds a new binding to both the visible and export namespaces, where the binding is associating the data [x] to the path [p].
       Conflicting names during the final merge will trigger the effect [shadow].
-      [include_singleton (p, x)] is [include_subtree Trie.(singleton (p, x))], but potentially more efficient.
+      [include_singleton (p, x)] is equivalent to [include_subtree Trie.(singleton (p, x))], but potentially more efficient.
 
       When implementing an OCaml-like language, this is how one can introduce a top-level definition [let p = x].
 
@@ -51,11 +51,11 @@ sig
   val import_singleton : ?context:context -> Trie.path * (data * tag) -> unit
   (** [import_singleton (p, x)] adds a new binding to the visible namespace (while keeping the export namespace intact), where the binding is associating the data [x] to the path [p].
       Conflicting names during the final merge will trigger the effect [shadow].
-      [import_singleton (p, x)] is [import_subtree Trie.(singleton (p, x))], but potentially more efficient.
+      [import_singleton (p, x)] is equivalent to [import_subtree Trie.(singleton (p, x))], but potentially more efficient.
 
       When implementing an OCaml-like language, one can implement the local binding [let p = x in e] as follows:
       {[
-        local @@ fun () ->
+        section [] @@ fun () ->
         import_singleton (p, x);
         (* code for handling the expression [e] *)
       ]}

--- a/src/ScopeSigs.ml
+++ b/src/ScopeSigs.ml
@@ -64,7 +64,7 @@ sig
       @since 4.1.0 *)
 
   val import_subtree : ?context:context -> Trie.path * (data, tag) Trie.t -> unit
-  (** [include_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
+  (** [import_subtree (p, ns)] merges the namespace [ns] prefixed with [p] into
       the visible namespace (while keeping the export namespace intact).
       Conflicting names during the final merge will trigger the effect [Mod.Shadowing].
 
@@ -104,7 +104,7 @@ sig
         let m = modify_standalone Language.(union [only ["x"]; only ["y"]]) m in
         import_subtree (["Mod"], m)
       ]}
-      The purpose of re-using the internal modifier engine is to share the same effect handling. For example, if one has already used {!val:run} or {!val:try_with} to mute the [shadow] effect, it also applies to the call of this [modify]. A new instance of {!module:Yuujinchou.Modifier.Make} will use fresh algebraic effects and thus existing effect handling will not apply.
+      The purpose of re-using the internal modifier engine is to share the same effect handling. For example, if one has already used {!val:run} or {!val:try_with} to mute the [Mod.Shadow] effect, it also applies to the call of this [modify]. A new instance of {!module:Yuujinchou.Modifier.Make} will use fresh algebraic effects and thus existing effect handling will not apply.
 
       This function will not lock the current scope, because it will not access the current scope.
       @since 4.1.0 *)
@@ -170,7 +170,7 @@ section {
 
       [try_with] is intended to be used within {!val:run} to intercept or reperform internal effects,
       while {!val:run} is intended to be at the top-level to set up the environment and handle all
-      effects by itself. For example, the following function silences the [shadow] effects, but the
+      effects by itself. For example, the following function silences the [Mod.Shadow] effects, but the
       silencing function should be used within the dynamic scope of a {!val:run}.
       See also {!val:Yuujinchou.Modifier.S.try_with}.
       {[

--- a/test/Example.ml
+++ b/test/Example.ml
@@ -86,7 +86,7 @@ let rec interpret_decl : decl -> unit =
     S.try_with ~shadow:S.Silence.shadow @@ fun () ->
     S.include_singleton (p, (x, `Local))
   | Import (t, m) ->
-    let t = S.modify m (Trie.Untagged.tag `Imported t) in
+    let t = S.modify_standalone m (Trie.Untagged.tag `Imported t) in
     S.import_subtree ([], t)
   | PrintVisible ->
     S.modify_visible (Language.hook Print)


### PR DESCRIPTION
This will be a big update...

1. Deprecate `Scope.modify` in favor of `Scope.modify_standalone` because I feel "modify" is too ambiguous
2. Add `import_singleton` to improve the support of local bindings.
3. Fix and clean up more documentation