### PR TITLE
feat(Language): add the abbreviation id = seq []

### DIFF
--- a/src/Language.ml
+++ b/src/Language.ml
@@ -17,6 +17,7 @@ let except p = in_ p none
 let renaming p p' = M_seq [M_in (p, M_assert_nonempty); M_renaming (p, p')]
 
 let seq ms = M_seq ms
+let id = seq []
 
 let hook f = M_hook f
 

--- a/src/LanguageSigs.ml
+++ b/src/LanguageSigs.ml
@@ -15,9 +15,15 @@ sig
   (** {2 Basics} *)
 
   (** [any] keeps the content of the current tree. It is an error if the tree is empty (no name to match).
-      To avoid the emptiness checking, use the identity modifier {!val:seq}[ []].
+      To avoid the emptiness checking, use the identity modifier {!val:id}.
       This is equivalent to {!val:only}[ []]. *)
   val any : 'hook t
+
+  (** [id] is {!val:seq}[ []], which keeps the content of the current tree.
+      This is different from {!val:any} because [id] does not check whether the tree is empty while {!val:any} does.
+
+      @since 5.0.0 *)
+  val id : 'hook t
 
   (** [only path] keeps the subtree rooted at [path]. It is an error if the subtree was empty. *)
   val only : Trie.path -> 'hook t
@@ -43,7 +49,7 @@ sig
   (** {2 Sequencing} *)
 
   (** [seq [m0; m1; m2; ...; mn]] runs the modifiers [m0], [m1], [m2], ..., [mn] in order.
-      In particular, [seq []] is the identity modifier. *)
+      In particular, [seq []] is the identity modifier {!val:id}. *)
   val seq : 'hook t list -> 'hook t
 
   (** {2 Union} *)


### PR DESCRIPTION
This will make it easier to describe the default value of the optional modifiers.

@jonsterling I have been thinking about a proper name for "`none` without emptiness checking" but couldn't come up with a good one. So far, there's no practical need, but I have been wondering...