### PR TITLE
fix(Language): rename `any` to `all`

### DIFF
--- a/src/Language.ml
+++ b/src/Language.ml
@@ -6,7 +6,7 @@ type 'hook t =
   | M_union of 'hook t list
   | M_hook of 'hook
 
-let any = M_assert_nonempty
+let all = M_assert_nonempty
 let none = M_seq [M_assert_nonempty; M_union []]
 
 let in_ p m = M_in (p, m)

--- a/src/LanguageSigs.ml
+++ b/src/LanguageSigs.ml
@@ -14,13 +14,13 @@ sig
 
   (** {2 Basics} *)
 
-  (** [any] keeps the content of the current tree. It is an error if the tree is empty (no name to match).
+  (** [all] keeps the content of the current tree. It is an error if the tree is empty (no name to match).
       To avoid the emptiness checking, use the identity modifier {!val:id}.
       This is equivalent to {!val:only}[ []]. *)
-  val any : 'hook t
+  val all : 'hook t
 
   (** [id] is {!val:seq}[ []], which keeps the content of the current tree.
-      This is different from {!val:any} because [id] does not check whether the tree is empty while {!val:any} does.
+      This is different from {!val:all} because [id] does not check whether the tree is empty while {!val:all} does.
 
       @since 5.0.0 *)
   val id : 'hook t
@@ -28,7 +28,7 @@ sig
   (** [only path] keeps the subtree rooted at [path]. It is an error if the subtree was empty. *)
   val only : Trie.path -> 'hook t
 
-  (** [in_ path m] runs the modifier [m] on the subtree rooted at [path]. Bindings outside the subtree are kept intact. For example, [in_ ["x"] ]{!val:any} will keep [y] (if existing), while {!val:only}[ ["x"]] will drop [y]. *)
+  (** [in_ path m] runs the modifier [m] on the subtree rooted at [path]. Bindings outside the subtree are kept intact. For example, [in_ ["x"] ]{!val:all} will keep [y] (if existing), while {!val:only}[ ["x"]] will drop [y]. *)
   val in_ : Trie.path -> 'hook t -> 'hook t
 
   (** {2 Negation} *)
@@ -42,7 +42,7 @@ sig
 
   (** {2 Renaming} *)
 
-  (** [renaming path path'] relocates the subtree rooted at [path] to [path']. The existing bindings at [path'] (if any) will be dropped.
+  (** [renaming path path'] relocates the subtree rooted at [path] to [path']. The existing bindings with the prefix [path'] (if any) will be dropped.
       It is an error if the subtree was empty (nothing to move). *)
   val renaming : Trie.path -> Trie.path -> 'hook t
 

--- a/test/TestModifier.ml
+++ b/test/TestModifier.ml
@@ -60,26 +60,26 @@ let test_none_3 () =
     (WrappedBindingNotFound Emp)
     (wrap_error @@ fun () -> M.modify none Trie.empty)
 
-let test_any_1 () =
+let test_all_1 () =
   Alcotest.(check @@ trie data) "ok"
     (of_list [["x"], N 10])
-    (wrap @@ fun () -> M.modify any (of_list [["x"], N 10]))
+    (wrap @@ fun () -> M.modify all (of_list [["x"], N 10]))
 
-let test_any_2 () =
+let test_all_2 () =
   Alcotest.(check @@ trie data) "ok"
     (of_list [[], N 10])
-    (wrap @@ fun () -> M.modify any (of_list [[], N 10]))
+    (wrap @@ fun () -> M.modify all (of_list [[], N 10]))
 
-let test_any_3 () =
+let test_all_3 () =
   Alcotest.check_raises "error"
     (WrappedBindingNotFound Emp)
-    (wrap_error @@ fun () -> M.modify any Trie.empty)
+    (wrap_error @@ fun () -> M.modify all Trie.empty)
 
-let test_any_4 () =
+let test_all_4 () =
   let t = of_list [[], N 10] in
   Alcotest.(check @@ trie data) "ok"
     t
-    (wrap @@ fun () -> M.modify any t)
+    (wrap @@ fun () -> M.modify all t)
 
 let test_only_1 () =
   Alcotest.(check @@ trie data) "ok"
@@ -130,7 +130,7 @@ let test_in_2 () =
 let test_in_3 () =
   Alcotest.check_raises "error"
     (WrappedBindingNotFound (Emp #< "x"))
-    (wrap_error @@ fun () -> M.modify (in_ ["x"] any) Trie.empty)
+    (wrap_error @@ fun () -> M.modify (in_ ["x"] all) Trie.empty)
 
 let test_in_4 () =
   let t = of_list [["x"; "y"], N 10; ["x"; "x"], N 20; ["y"], N 30] in
@@ -180,7 +180,7 @@ let test_seq_1 () =
 let test_seq_2 () =
   Alcotest.check_raises "error"
     (WrappedBindingNotFound Emp)
-    (wrap_error @@ fun () -> M.modify (seq [none; any]) (of_list [["x"; "y"], N 10; ["x"; "x"], N 20; ["y"], N 30]))
+    (wrap_error @@ fun () -> M.modify (seq [none; all]) (of_list [["x"; "y"], N 10; ["x"; "x"], N 20; ["y"], N 30]))
 
 let test_seq_3 () =
   Alcotest.check_raises "error"
@@ -229,11 +229,11 @@ let () =
       test_case "none" `Quick test_none_2;
       test_case "none" `Quick test_none_3;
     ];
-    "any", [
-      test_case "any" `Quick test_any_1;
-      test_case "any" `Quick test_any_2;
-      test_case "any" `Quick test_any_3;
-      test_case "any" `Quick test_any_4;
+    "all", [
+      test_case "all" `Quick test_all_1;
+      test_case "all" `Quick test_all_2;
+      test_case "all" `Quick test_all_3;
+      test_case "all" `Quick test_all_4;
     ];
     "only", [
       test_case "only" `Quick test_only_1;


### PR DESCRIPTION
`all` is much better than `any`